### PR TITLE
fix: correct type casting

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,5 +1,5 @@
-import { Error, Form, FormResult, Input, Radio, RadioGroup, Select, Textarea } from '../../.'
 import WithHOCSelect from './select'
+import { Error, Form, FormResult, Input, Radio, RadioGroup, Select, Textarea } from 'kingpin-react-form'
 import { FormEvent, useRef } from 'react'
 
 function App(): JSX.Element {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,5 +1,5 @@
+import { Error, Form, FormResult, Input, Radio, RadioGroup, Select, Textarea } from '../../.'
 import WithHOCSelect from './select'
-import { Error, Form, FormResult, Input, Radio, RadioGroup, Select, Textarea } from 'kingpin-react-form'
 import { FormEvent, useRef } from 'react'
 
 function App(): JSX.Element {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kingpin-react-form",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": "Valerio Ageno <valerioageno@yahoo.it>",
   "module": "dist/kingpin-react-form.esm.js",
   "license": "MIT",

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -1,5 +1,6 @@
 import { removeKeysFromObject } from './helpers'
-import withKingpin, { WithKingpinType } from './withKingpin'
+import type { WithKingpinProps, WithKingpinType } from './types'
+import withKingpin from './withKingpin'
 import React, { ChangeEvent, FunctionComponent, InputHTMLAttributes } from 'react'
 
 type ReturnTypes = string | number | boolean
@@ -41,4 +42,4 @@ const KingpinInput = withKingpin<Props, ReturnTypes>((props: Props): JSX.Element
 
 KingpinInput.displayName = 'KingpinInput'
 
-export default KingpinInput as unknown as FunctionComponent<Props>
+export default KingpinInput as unknown as FunctionComponent<WithKingpinProps<ReturnTypes> & Props>

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -1,6 +1,6 @@
 import { removeKeysFromObject } from './helpers'
 import withKingpin, { WithKingpinType } from './withKingpin'
-import React, { ChangeEvent, InputHTMLAttributes } from 'react'
+import React, { ChangeEvent, FunctionComponent, InputHTMLAttributes } from 'react'
 
 type ReturnTypes = string | number | boolean
 
@@ -41,4 +41,4 @@ const KingpinInput = withKingpin<Props, ReturnTypes>((props: Props): JSX.Element
 
 KingpinInput.displayName = 'KingpinInput'
 
-export default KingpinInput
+export default KingpinInput as unknown as FunctionComponent<Props>

--- a/src/Radio.tsx
+++ b/src/Radio.tsx
@@ -1,6 +1,6 @@
 import { useRadioGroupContext } from './RadioGroup'
 import { useIsomorphicEffect } from './helpers'
-import { WithKingpinType } from './withKingpin'
+import type { WithKingpinType } from './types'
 import { InputHTMLAttributes } from 'react'
 import React from 'react'
 

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -1,5 +1,6 @@
 import { removeKeysFromObject } from './helpers'
-import withKingpin, { WithKingpinType } from './withKingpin'
+import type { WithKingpinProps, WithKingpinType } from './types'
+import withKingpin from './withKingpin'
 import React, { FunctionComponent, SelectHTMLAttributes } from 'react'
 
 type Props = SelectHTMLAttributes<HTMLSelectElement> & WithKingpinType<string>
@@ -20,4 +21,4 @@ const KingpinSelect = withKingpin<Props, string>(
 )
 KingpinSelect.displayName = 'KingpinSelect'
 
-export default KingpinSelect as unknown as FunctionComponent<Props>
+export default KingpinSelect as unknown as FunctionComponent<WithKingpinProps<string> & Props>

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -1,6 +1,6 @@
 import { removeKeysFromObject } from './helpers'
 import withKingpin, { WithKingpinType } from './withKingpin'
-import React, { SelectHTMLAttributes } from 'react'
+import React, { FunctionComponent, SelectHTMLAttributes } from 'react'
 
 type Props = SelectHTMLAttributes<HTMLSelectElement> & WithKingpinType<string>
 
@@ -19,4 +19,5 @@ const KingpinSelect = withKingpin<Props, string>(
   ),
 )
 KingpinSelect.displayName = 'KingpinSelect'
-export default KingpinSelect
+
+export default KingpinSelect as unknown as FunctionComponent<Props>

--- a/src/Textarea.tsx
+++ b/src/Textarea.tsx
@@ -1,5 +1,6 @@
 import { removeKeysFromObject } from './helpers'
-import withKingpin, { WithKingpinType } from './withKingpin'
+import type { WithKingpinProps, WithKingpinType } from './types'
+import withKingpin from './withKingpin'
 import React, { FunctionComponent, TextareaHTMLAttributes } from 'react'
 
 type Props = TextareaHTMLAttributes<HTMLTextAreaElement> & WithKingpinType<string>
@@ -24,4 +25,4 @@ const KingpinTextarea = withKingpin<Props, string>(
 
 KingpinTextarea.displayName = 'KingpinTextarea'
 
-export default KingpinTextarea as unknown as FunctionComponent<Props>
+export default KingpinTextarea as unknown as FunctionComponent<WithKingpinProps<string> & Props>

--- a/src/Textarea.tsx
+++ b/src/Textarea.tsx
@@ -1,6 +1,6 @@
 import { removeKeysFromObject } from './helpers'
 import withKingpin, { WithKingpinType } from './withKingpin'
-import React, { TextareaHTMLAttributes } from 'react'
+import React, { FunctionComponent, TextareaHTMLAttributes } from 'react'
 
 type Props = TextareaHTMLAttributes<HTMLTextAreaElement> & WithKingpinType<string>
 
@@ -24,4 +24,4 @@ const KingpinTextarea = withKingpin<Props, string>(
 
 KingpinTextarea.displayName = 'KingpinTextarea'
 
-export default KingpinTextarea
+export default KingpinTextarea as unknown as FunctionComponent<Props>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,15 +1,31 @@
+import type { ForwardRefExoticComponent, PropsWithoutRef, RefAttributes } from 'react'
+
 export type FormResult = {
   isFormValid: boolean
   payload: Record<string, Value>
 }
+
 export type InputEffect<T> = {
   sendData?: () => Result<T>
   reset?: () => void
   checkValidation?: () => boolean
   shouldShowError?: (e: Set<string>) => void
 }
+export type KingpinComponent<T, State> = ForwardRefExoticComponent<
+  PropsWithoutRef<Omit<T, 'updateState'> & WithKingpinProps<State>> & RefAttributes<InputEffect<State>>
+>
 
 export type Result<T> = { name: string; value: T }
 
 export type ValidationFn<State> = (s: State) => boolean
 export type Value = string | number | boolean | readonly string[]
+
+export type WithKingpinProps<T> = {
+  name: string
+  initialValue: T
+  validation?: ValidationFn<T> | ValidationFn<T>[]
+}
+
+export type WithKingpinType<T> = {
+  updateState?: (val: T) => void
+}

--- a/src/withKingpin.tsx
+++ b/src/withKingpin.tsx
@@ -1,19 +1,6 @@
 import useValidation from './hooks/useValidation'
-import type { InputEffect, Result, ValidationFn } from './types'
-import React, { ComponentType, ForwardRefExoticComponent, forwardRef, useImperativeHandle, useState } from 'react'
-
-export type KingpinComponent<T, State> = ForwardRefExoticComponent<
-  React.PropsWithoutRef<Omit<T, 'updateState'> & WithKingpinProps<State>> & React.RefAttributes<InputEffect<State>>
->
-export type WithKingpinType<T> = {
-  updateState?: (val: T) => void
-}
-
-type WithKingpinProps<T> = {
-  name: string
-  initialValue: T
-  validation?: ValidationFn<T> | ValidationFn<T>[]
-}
+import type { InputEffect, KingpinComponent, Result, WithKingpinProps } from './types'
+import React, { ComponentType, forwardRef, useImperativeHandle, useState } from 'react'
 
 /**
  * @description Trasnform the passed WrappedComponent into an input usable by the Kingpin form component.


### PR DESCRIPTION
Because of the withKingpin HOC internal use the components built within the library have a wrong type. This PR correct the typecasting forcing it manually.